### PR TITLE
FIX: IPython directive requires matplotlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ipython
+matplotlib
 sphinx
 sphinx_rtd_theme


### PR DESCRIPTION
IPython does not require `matplotlib`. IPython directive does